### PR TITLE
- Removed redeclaration of handle method

### DIFF
--- a/src/Command/QueueQueueCheckCommand.php
+++ b/src/Command/QueueQueueCheckCommand.php
@@ -53,16 +53,6 @@ class QueueQueueCheckCommand extends Command
     }
 
     /**
-     * Execute the console command for Laravel 5.5+
-     *
-     * @return mixed
-     */
-    public function handle()
-    {
-        $this->fire();
-    }
-
-    /**
      * Get the console command arguments.
      *
      * @return array


### PR DESCRIPTION
I'm glad to see support for Laravel 5.5, but you accidentally included a redeclaration of the handle method.